### PR TITLE
now we have gulp default task and others for production and tests.

### DIFF
--- a/gulp/babel_compile.js
+++ b/gulp/babel_compile.js
@@ -1,0 +1,10 @@
+const gulp = require('gulp');
+const babel = require('gulp-babel');
+
+gulp.task('babel-compile', () => {
+  return gulp.src('src/server.js')
+    .pipe(babel({
+      presets: ['es2015']
+    }))
+    .pipe(gulp.dest('index'));
+});

--- a/gulp/integration_tests.js
+++ b/gulp/integration_tests.js
@@ -1,0 +1,7 @@
+var gulp = require('gulp');
+var shell = require('gulp-shell');
+
+gulp.task('integrationTests', () => {
+    return gulp.src('index.js')
+        .pipe(shell('npm test'))
+});

--- a/gulp/tests.js
+++ b/gulp/tests.js
@@ -1,0 +1,6 @@
+var gulp = require('gulp');
+var shell = require('gulp-shell');
+
+gulp.task('test', ['integrationTests'], (done) => {
+    done();
+});

--- a/gulp/watch.js
+++ b/gulp/watch.js
@@ -1,0 +1,17 @@
+const gulp = require('gulp');
+const nodemon = require('gulp-nodemon');
+const notify = require('gulp-notify');
+const livereload = require('gulp-livereload');
+
+gulp.task('watch', () => {
+  livereload.listen();
+  nodemon({
+    script: 'index.js',
+    ext: 'js'
+  }).on('restart', () =>{
+    gulp.start('babel-compile')
+      .src('app.js')
+      .pipe(livereload())
+      .pipe(notify('Reloading page, please wait...'));
+  });
+});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,11 @@
+const gulp = require('gulp');
+require('require-dir')('./gulp');
+
+gulp.task('default', ['babel-compile'], (done) => {
+  gulp.start('watch');
+  done();
+});
+
+gulp.task('production', ['babel-compile', 'test'], (done) => {
+  done();
+});

--- a/index/server.js
+++ b/index/server.js
@@ -1,0 +1,31 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _config = require('./config');
+
+var _config2 = _interopRequireDefault(_config);
+
+var _routes = require('./config/routes');
+
+var _routes2 = _interopRequireDefault(_routes);
+
+var _koa = require('koa');
+
+var _koa2 = _interopRequireDefault(_koa);
+
+var _koa3 = require('./config/koa');
+
+var _koa4 = _interopRequireDefault(_koa3);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var app = new _koa2.default();
+app.port = _config2.default.port;
+
+(0, _koa4.default)(app);
+(0, _routes2.default)(app);
+
+exports.default = app;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "babel-plugin-transform-runtime": "^6.9.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-0": "^6.5.0",
-    "babel-register": "^6.9.0",
     "forever": "^0.15.2",
     "koa": "^2.0.0",
     "koa-morgan": "^1.0.1",
@@ -23,21 +22,30 @@
     "koa-router": "^7.0.1"
   },
   "devDependencies": {
+    "babel-preset-es2015": "^6.18.0",
+    "chai": "^3.5.0",
     "eslint": "^2.13.1",
     "eslint-config-airbnb": "^9.0.1",
     "eslint-plugin-import": "^1.9.2",
     "eslint-plugin-jsx-a11y": "^1.5.3",
     "eslint-plugin-react": "^5.2.2",
-    "chai": "^3.5.0",
+    "express": "^4.14.0",
+    "gulp": "^3.9.1",
+    "gulp-babel": "^6.1.2",
+    "gulp-livereload": "^3.8.1",
+    "gulp-nodemon": "^2.2.1",
+    "gulp-notify": "^2.2.0",
+    "gulp-shell": "^0.5.2",
     "mocha": "^2.5.3",
-    "supertest": "^1.2.0",
-    "npm-watch": "^0.1.4"
+    "npm-watch": "^0.1.4",
+    "require-dir": "^0.3.1",
+    "supertest": "^1.2.0"
   },
   "engines": {
     "node": "~5.4.1"
   },
   "scripts": {
-    "start": "node index.js",
+    "start": "nodemon --harmony index.js",
     "serve": "node index.js",
     "cluster": "koa-cluster index.js",
     "forever": "forever start index.js",

--- a/src/api/root/root.model.js
+++ b/src/api/root/root.model.js
@@ -6,6 +6,6 @@ export function list() {
   return new Promise((resolve) => {
     setTimeout(() => {
       resolve(config);
-    });
+    }, 0);
   });
 }


### PR DESCRIPTION
* Livereload of the server.
* Task to have the babel compile functionality with gulp for easier reuse inside of it.
* Test task for gulp (so we can reuse it for production task).
* Production task, It basically compiles the project and run the tests for it.
* Default tasks that will run the watcher and this one itselft will recompile all the files with babel and restart the server anytime a change is made to the source of the project.